### PR TITLE
Correct data manager usage example

### DIFF
--- a/book/transactions.rst
+++ b/book/transactions.rst
@@ -1116,7 +1116,7 @@ quick example:
     import transaction
     from pickledm import PickleDataManager
 
-    dm = PickleDataManager
+    dm = PickleDataManager()
     t = tranaction.get()
     t.join(dm)
     dm['bar'] = 'foo'


### PR DESCRIPTION
Usage of the PickleDataManager needs an instance, rather than the class itself.
